### PR TITLE
Correcting a logical error in the definition

### DIFF
--- a/src/acode.d.ts
+++ b/src/acode.d.ts
@@ -139,7 +139,7 @@ declare namespace Acode {
     loader: Loader;
     multiprompt: MultiPrompt;
     openfolder: OpenFolder;
-    page: WCPage;
+    page: Page;
     palette: Palette;
     projects: Projects;
     prompt: Prompt;


### PR DESCRIPTION
For returning functions acode.require("page") there is a separate Page interface, instead of which, apparently by accident, WCPage was provided.